### PR TITLE
Force Path of Magic hint

### DIFF
--- a/data/Hints/very_strong_magic.json
+++ b/data/Hints/very_strong_magic.json
@@ -10,7 +10,7 @@
     "dungeons_barren_limit": 40,
     "named_items_required":  true,
     "vague_named_items":     false,
-    "use_default_goals":     true,
+    "use_default_goals":     false,
     "distribution":          {
         "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 1},
         "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 2},
@@ -25,7 +25,7 @@
         "dungeon":    {"order": 11, "weight": 1.5, "fixed":   0, "copies": 1},
         "junk":       {"order": 12, "weight": 0.0, "fixed":   0, "copies": 1},
         "named-item": {"order": 13, "weight": 0.0, "fixed":   0, "copies": 1},
-        "goal":       {"order": 14, "weight": 0.0, "fixed":   0, "copies": 1}
+        "goal":       {"order": 14, "weight": 0.0, "fixed":   1, "copies": 2}
     },
     "custom_goals": [
         {


### PR DESCRIPTION
Prevents hinting any of the default goals, and adds a fixed hint for Path of Magic. I've tested it, and seems to consistently generate one Path of Magic hint with two copies. Unclear whether it should have one or two copies, since the numbers vary by type in this hint distro, but that's easy to change.